### PR TITLE
Gestion de liste des projets encours via API et non plus via Jinja

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,28 +68,28 @@ def close_database_connection(exception=None):
         base_de_donnees.connexion_close()
 
 
-# Définition de la route pour afficher la liste des projets en cours
-@app.route('/Tableau_de_bord_JARNOT/Projets/')
-def tableau_de_bord():
+# Définition de la route pour retourner la liste des projets en cours
+@app.route('/Tableau_de_bord_JARNOT/Liste_Projets/')
+def Liste_Projets():
     base_de_donnees = get_database()
     projets = base_de_donnees.get_all_projets()
-    liste_profils = base_de_donnees.get_profils_user(current_user.nom)
-    return render_template('Tableau_de_Bord.html', projets=projets, name=current_user.nom, liste_profils=liste_profils)
+    return jsonify(projets)
 
 
 # Définition de la route pour afficher le détail d'un projet
 @app.route('/Tableau_de_bord_JARNOT/Projets/<int:projet_id>')
+@app.route('/Tableau_de_bord_JARNOT/Projets/')
 @login_required
-def detail_projet(projet_id):
+def detail_projet(projet_id = 0):
     base_de_donnees = get_database()
-
-    projets = base_de_donnees.get_all_projets()
-    projet = base_de_donnees.get_info_projet_by_id(projet_id)
-    ops_projet = base_de_donnees.get_ops_by_id_projet(projet_id)
     liste_profils = base_de_donnees.get_profils_user(current_user.nom)
-
-    return render_template('Tableau_de_Bord.html', projets=projets, projet=projet, ops_projet=ops_projet, name=current_user.nom, liste_profils=liste_profils)
-
+    if projet_id > 0 :
+        projet = base_de_donnees.get_info_projet_by_id(projet_id)
+        ops_projet = base_de_donnees.get_ops_by_id_projet(projet_id)
+        return render_template('Tableau_de_Bord.html', projet=projet, ops_projet=ops_projet, name=current_user.nom, liste_profils=liste_profils)
+    else:
+        return render_template('Tableau_de_Bord.html', name=current_user.nom, liste_profils=liste_profils)
+    
 
 # Définition de la route pour mettre à jour le statut de l'opération
 @app.route('/Tableau_de_bord_JARNOT/update_statut/', methods=['PUT'])

--- a/models.py
+++ b/models.py
@@ -86,10 +86,9 @@ class AccesBDD:
         rows = curseur.fetchall()
         curseur.close()
 
-        projets = {}
+        projets = []
         for id, nom, version, nb_ops_non_finies in rows:
-            projets[id] = {'nom': nom, 'version': version, 'nb_ops_non_finies': nb_ops_non_finies}
-
+            projets.append({'id':id,'nom': nom, 'version': version, 'nb_ops_non_finies': nb_ops_non_finies})
         return projets
 
     def get_info_projet_by_id(self, projet_id):

--- a/static/js/clic_bouton_projets.js
+++ b/static/js/clic_bouton_projets.js
@@ -1,19 +1,37 @@
-// Rafraîchit la page lorsqu'on clique sur le bouton "Projets" mettant à jour la liste des projets
-let dropdown = document.querySelector('#dropdown ul');
+// Description: Gestion de l'affichage et la mise à jour du menu déroulant des projets
 
-document.getElementById('dropdown').addEventListener('click', function() {
-  // location.reload();
-  if (dropdown.style.display === 'block') {
-    dropdown.style.display = 'none';
-  } else {
-    dropdown.style.display = 'block';
+var dropdown = document.getElementById('dropdown');
+var listeProjets = document.getElementById('listeProjets');
+
+function mettreAJourListeProjets() {
+  // Supprimer les éléments existants de la liste
+  while (listeProjets.firstChild) {
+    listeProjets.removeChild(listeProjets.firstChild);
   }
-});
 
-let listItems = document.querySelectorAll('#dropdown ul li');
-listItems.forEach(function(li) {
-  li.addEventListener('click', function() {
-    let dropdown = document.querySelector('#dropdown ul');
-    dropdown.style.display = 'none';
-  });
+  // Récup les projets depuis le serveur
+  fetch('/Tableau_de_bord_JARNOT/Liste_Projets/')
+    .then(response => response.json())
+    .then(data => {
+      // Remplit la liste des projets avec les données récupérées
+      data.forEach(function(prj) {
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+        a.href = "/Tableau_de_bord_JARNOT/Projets/" + prj.id;
+        a.textContent = prj.nom + " (" + prj.nb_ops_non_finies + ")";
+        li.appendChild(a);
+        listeProjets.appendChild(li);
+      });
+    })
+    .catch(error => console.error('Erreur lors de la récupération des projets:', error));
+}
+
+// Gestion de l'affichage et la mise à jour du menu déroulant à chaque clic sur le bouton "Projets"
+dropdown.addEventListener('click', function() {
+  if (listeProjets.style.display === 'none') {
+    mettreAJourListeProjets();
+    listeProjets.style.display = 'block';
+  } else {
+    listeProjets.style.display = 'none';
+  }
 });

--- a/templates/Tableau_de_Bord.html
+++ b/templates/Tableau_de_Bord.html
@@ -17,15 +17,7 @@
       {% else %}
         PROJETS ?
       {% endif %}
-      <ul>
-        {% if projets is defined %}
-          {% for prj in projets %}
-            <li>
-              <a href="/Tableau_de_bord_JARNOT/Projets/{{ prj }} ">{{ projets[prj]['nom'] }}</a>&nbsp;&nbsp;({{ projets[prj]['nb_ops_non_finies'] }})
-            </li>
-          {% endfor %}
-        {% endif %}
-      </ul>
+      <ul id="listeProjets" style="display:none;"></ul>
     </button>
 
     {% if projet is defined %}


### PR DESCRIPTION
permettant de mettre à jours la liste dynamiquement en cliquant sur le bouton "PROJETS" et uniquement la liste (pas la page entière)